### PR TITLE
Update dev-install instructions and update package.json scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,26 +48,40 @@ is used instead.
 
 ```bash
 # Create a new conda environment
-conda create -n jupyterlab-sidecar -c conda-forge jupyterlab ipywidgets nodejs
+conda create -n jupyterlab-sidecar -c conda-forge jupyterlab ipywidgets nodejs -y
 
 # Activate the conda environment
 conda activate jupyterlab-sidecar
 
-# Install dependencies
-jlpm
-
-# Build Typescript source
-jlpm build
+# Install package in development mode
+pip install -e .
 
 # Link your development version of the extension with JupyterLab
-jupyter labextension link .
+jupyter labextension develop . --overwrite
 
-# Rebuild Typescript source after making changes
-jlpm build
+# Rebuild extension Typescript source after making changes
+jlpm run build
+```
+You can watch the source directory and run JupyterLab at the same time in different terminals to watch for changes in the extension's source and automatically rebuild the extension.
 
-# Rebuild JupyterLab after making any changes
-jupyter lab build
+```bash
+# Watch the source directory in one terminal, automatically rebuilding when needed
+jlpm run watch
+# Run JupyterLab in another terminal
+jupyter lab
+```
 
-# Install the sidecar Python package
-python -m pip install -e .
+
+With the watch command running, every saved change will immediately be built locally and available in your running JupyterLab. Refresh JupyterLab to load the change in your browser (you may need to wait several seconds for the extension to be rebuilt).
+
+By default, the jlpm run build command generates the source maps for this extension to make it easier to debug using the browser dev tools. To also generate source maps for the JupyterLab core extensions, you can run the following command:
+
+```bash
+jupyter lab build --minimize=False
+```
+
+## Uninstall
+
+```
+pip uninstall jupyterlab-sidecar
 ```

--- a/package.json
+++ b/package.json
@@ -21,20 +21,25 @@
     "url": "https://github.com/jupyter-widgets/jupyterlab-sidecar"
   },
   "scripts": {
-    "build": "jlpm run build:lib && jlpm run build:labextension",
+    "build": "jlpm run build:lib && jlpm run build:labextension:dev",
+    "build:prod": "jlpm run build:lib && jlpm run build:labextension",
     "build:labextension": "jupyter labextension build .",
+    "build:labextension:dev": "jupyter labextension build --development True .",
     "build:lib": "tsc",
-    "clean": "jlpm run clean:lib && jlpm run clean:labextension",
-    "clean:lib": "rimraf lib",
+    "clean": "jlpm run clean:lib",
+    "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
     "clean:labextension": "rimraf sidecar/labextension",
-    "prepare": "jlpm run build",
+    "clean:all": "jlpm run clean:lib && jlpm run clean:labextension",
     "test": "jlpm run test:firefox",
     "test:chrome": "karma start --browsers=Chrome tests/karma.conf.js",
     "test:debug": "karma start --browsers=Chrome --singleRun=false --debug=true tests/karma.conf.js",
     "test:firefox": "karma start --browsers=Firefox tests/karma.conf.js",
     "test:ie": "karma start --browsers=IE tests/karma.conf.js",
-    "watch": "npm-run-all -p watch:*",
-    "watch:lib": "tsc"
+    "install:extension": "jupyter labextension develop --overwrite .",
+    "prepare": "jlpm run clean && jlpm run build:prod",
+    "watch": "run-p watch:src watch:labextension",
+    "watch:src": "tsc -w",
+    "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
     "@jupyter-widgets/base": "^4.0.0",


### PR DESCRIPTION
fixes: https://github.com/jupyter-widgets/jupyterlab-sidecar/issues/56

1. Update the dev install instructions to work in jlab3
2. Update scripts based on https://github.com/jupyterlab/extension-cookiecutter-ts/blob/3.0/%7B%7Bcookiecutter.python_name%7D%7D/package.json
    - Previous watch mode wouldn't actually watch, I fixed that and updated the others for good measure.